### PR TITLE
Remove switch labels from flip controls

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -16,23 +16,15 @@ $(function(){
 
     var loadButton = function(){
       if(FlipX === "on"){
-        $("#switch").text("ON");
-        $("#switch").css('color','#00aced');
-        $("#flipX").css({'color':'#fff','background-color':'#00aced'});	
+        $("#flipX").css({'color':'#fff','background-color':'#00aced'});
       } else {
-        $("#switch").text("OFF");
-        $("#switch").css('color','#666');
-        $("#flipX").css({'color':'#666','background-color':'#fff'});		
+        $("#flipX").css({'color':'#666','background-color':'#fff'});
       }
 
       if(FlipY === "on"){
-        $("#switch2").text("ON");
-        $("#switch2").css('color','#00aced');
-        $("#flipY").css({'color':'#fff','background-color':'#00aced'});	
+        $("#flipY").css({'color':'#fff','background-color':'#00aced'});
       } else {
-        $("#switch2").text("OFF");
-        $("#switch2").css('color','#666');
-        $("#flipY").css({'color':'#666','background-color':'#fff'});		
+        $("#flipY").css({'color':'#666','background-color':'#fff'});
       }
 
       $("#rotate").val(Rotate);
@@ -41,36 +33,28 @@ $(function(){
     loadButton();	
 
     var setButtonX = function(){
-      var flipXmode = $("#switch").text();
       var option = {};
-      if(flipXmode === "ON"){
-        $("#switch").text("OFF");			
-        $("#switch").css('color','#666');
-        $("#flipX").css({'color':'#666','background-color':'#fff'});	
-        option.FlipX= "off";
+      if(FlipX === "on"){
+        $("#flipX").css({'color':'#666','background-color':'#fff'});
+        FlipX = "off";
       } else {
-        $("#switch").text("ON");
-        $("#switch").css('color','#00aced');
         $("#flipX").css({'color':'#fff','background-color':'#00aced'});
-        option.FlipX= "on";
+        FlipX = "on";
       }
+      option.FlipX = FlipX;
       chrome.storage.sync.set(option);
-    };	
+    };
 
-    var setButtonY = function(){		
-      var flipYmode = $("#switch2").text();
+    var setButtonY = function(){
       var option = {};
-      if(flipYmode === "ON"){
-        $("#switch2").text("OFF");			
-        $("#switch2").css('color','#666');
-        $("#flipY").css({'color':'#666','background-color':'#fff'});	
-        option.FlipY= "off";
+      if(FlipY === "on"){
+        $("#flipY").css({'color':'#666','background-color':'#fff'});
+        FlipY = "off";
       } else {
-        $("#switch2").text("ON");
-        $("#switch2").css('color','#00aced');
         $("#flipY").css({'color':'#fff','background-color':'#00aced'});
-        option.FlipY= "on";
+        FlipY = "on";
       }
+      option.FlipY = FlipY;
       chrome.storage.sync.set(option);
     };
 

--- a/options.html
+++ b/options.html
@@ -8,11 +8,9 @@
   <link rel="stylesheet" href="css/popup.css" type="text/css">
 </head>
 <body style="width:220px; margin:30px 0 20px 0; text-align:center; background:#fff;">
-  <font size="-1"><button id="flipX">左右反転</button><br></font>
-  <strong><span id="switch" style="color:#666;">OFF</span></strong><br><br>
+  <font size="-1"><button id="flipX">左右反転</button><br></font><br>
 
-  <font size="-1"><button id="flipY">上下反転</button><br></font>
-  <strong><span id="switch2" style="color:#666;">OFF</span></strong><br><br>
+  <font size="-1"><button id="flipY">上下反転</button><br></font><br>
 
   <select id="rotate" name="回転" style="display:none;">
     <option value="0">0°</option>

--- a/popup.html
+++ b/popup.html
@@ -8,11 +8,9 @@
   <link rel="stylesheet" href="css/popup.css" type="text/css">
 </head>
 <body style="width:220px; margin:30px 0 20px 0; text-align:center; background:#fff;">
-  <font size="-1"><button id="flipX">左右反転</button><br></font>
-  <strong><span id="switch" style="color:#666;">OFF</span></strong><br><br>
+  <font size="-1"><button id="flipX">左右反転</button><br></font><br>
 
-  <font size="-1"><button id="flipY">上下反転</button><br></font>
-  <strong><span id="switch2" style="color:#666;">OFF</span></strong><br><br>
+  <font size="-1"><button id="flipY">上下反転</button><br></font><br>
 
   <select id="rotate" name="回転" style="display:none;">
     <option value="0">0°</option>


### PR DESCRIPTION
## Summary
- remove ON/OFF labels from popup and options
- drop text toggling logic in `popup.js`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68428c9174b08329bcfc6e17e493c229