### PR TITLE
Reduce jog dial size

### DIFF
--- a/js/dial.js
+++ b/js/dial.js
@@ -9,9 +9,10 @@
   const angleText   = document.getElementById('angle-display');
   const rotateSel   = document.getElementById('rotate');
 
-  const center = { x: 100, y: 100 };
-  const innerRadius = 65;
-  const outerRadius = 95;
+  // サイズを 7 割程度に縮小
+  const center = { x: 70, y: 70 };
+  const outerRadius = 67;
+  const innerRadius = outerRadius - 30;  // ヌブ帯の幅を維持
   const nubRadius   = (innerRadius + outerRadius) / 2;
 
   let dragging = false;

--- a/options.html
+++ b/options.html
@@ -17,11 +17,11 @@
   </select>
 
   <div id="dial-container">
-    <svg id="dial" width="200" height="200" viewBox="0 0 200 200">
-      <circle id="outer" cx="100" cy="100" r="95" />
-      <circle id="inner" cx="100" cy="100" r="65" />
-      <circle id="nub" cx="100" cy="80" r="10" />
-      <text id="angle-display" x="100" y="100" text-anchor="middle" font-size="24" dominant-baseline="middle">0°</text>
+    <svg id="dial" width="140" height="140" viewBox="0 0 140 140">
+      <circle id="outer" cx="70" cy="70" r="67" />
+      <circle id="inner" cx="70" cy="70" r="37" />
+      <circle id="nub" cx="70" cy="50" r="10" />
+      <text id="angle-display" x="70" y="70" text-anchor="middle" font-size="17" dominant-baseline="middle">0°</text>
     </svg>
   
   <!-- 角度調整ボタン -->

--- a/popup.html
+++ b/popup.html
@@ -17,11 +17,11 @@
   </select>
 
   <div id="dial-container">
-    <svg id="dial" width="200" height="200" viewBox="0 0 200 200">
-      <circle id="outer" cx="100" cy="100" r="95" />
-      <circle id="inner" cx="100" cy="100" r="65" />
-      <circle id="nub" cx="100" cy="80" r="10" />
-      <text id="angle-display" x="100" y="100" text-anchor="middle" font-size="24" dominant-baseline="middle">0°</text>
+    <svg id="dial" width="140" height="140" viewBox="0 0 140 140">
+      <circle id="outer" cx="70" cy="70" r="67" />
+      <circle id="inner" cx="70" cy="70" r="37" />
+      <circle id="nub" cx="70" cy="50" r="10" />
+      <text id="angle-display" x="70" y="70" text-anchor="middle" font-size="17" dominant-baseline="middle">0°</text>
     </svg>
   
   <!-- 角度調整ボタン -->


### PR DESCRIPTION
## Summary
- shrink jog dial diameter to 70% and keep gray band width
- adjust center coordinates and angle text size

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68428fbe94648329a932cde64cd2ccb0