### PR TITLE
Add hue, saturation and invert sliders

### DIFF
--- a/js/contents.js
+++ b/js/contents.js
@@ -6,6 +6,9 @@ var setAll = function(){
             Rotate = items.Rotate || "0",
             Brightness = items.Brightness || 0,
             Contrast = items.Contrast || 0,
+            Hue = items.Hue || 0,
+            Saturation = items.Saturation || 0,
+            Invert = items.Invert || 0,
             img = 'img, div';
 
         var scale = " scale(1,1)";
@@ -32,7 +35,10 @@ var setAll = function(){
         $('embed').css({'transform': transform});
 
         var filter = 'brightness(' + ((100 + parseInt(Brightness,10)) / 100) +
-                     ') contrast(' + ((100 + parseInt(Contrast,10)) / 100) + ')';
+                     ') contrast(' + ((100 + parseInt(Contrast,10)) / 100) +
+                     ') hue-rotate(' + parseInt(Hue,10) + 'deg)' +
+                     ' saturate(' + ((100 + parseInt(Saturation,10)) / 100) +
+                     ') invert(' + (parseInt(Invert,10) / 100) + ')';
         $(img).each(function(){
             if($(this).is('img') || $(this).css('background-image') !== 'none'){
                 $(this).css({'filter': filter});
@@ -48,9 +54,12 @@ chrome.storage.onChanged.addListener(function(changes, namespace) {
 });
 
 // Popupからの更新要求
-var applyFilters = function(bright, cont) {
+var applyFilters = function(bright, cont, hue, sat, inv) {
     var filter = 'brightness(' + ((100 + parseInt(bright, 10)) / 100) +
-                 ') contrast(' + ((100 + parseInt(cont, 10)) / 100) + ')';
+                 ') contrast(' + ((100 + parseInt(cont, 10)) / 100) +
+                 ') hue-rotate(' + parseInt(hue, 10) + 'deg)' +
+                 ' saturate(' + ((100 + parseInt(sat, 10)) / 100) +
+                 ') invert(' + (parseInt(inv, 10) / 100) + ')';
     $('img, div').each(function(){
         if($(this).is('img') || $(this).css('background-image') !== 'none'){
             $(this).css({'filter': filter});
@@ -63,7 +72,8 @@ chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
     if (message && message.type === 'refresh') {
         setAll();
     } else if (message && message.type === 'updateFilters') {
-        applyFilters(message.brightness, message.contrast);
+        applyFilters(message.brightness, message.contrast,
+                     message.hue, message.saturate, message.invert);
     }
 });
 });//一番外側のfunctionの終わり

--- a/options.html
+++ b/options.html
@@ -21,6 +21,18 @@
     <label for="contrast">コントラスト</label><br>
     <input id="contrast" type="range" min="-100" max="100" value="0">
   </div>
+  <div style="margin-top:5px;">
+    <label for="hue">色相</label><br>
+    <input id="hue" type="range" min="-180" max="180" value="0">
+  </div>
+  <div style="margin-top:5px;">
+    <label for="saturate">彩度</label><br>
+    <input id="saturate" type="range" min="-100" max="100" value="0">
+  </div>
+  <div style="margin-top:5px;">
+    <label for="invert">階調の反転</label><br>
+    <input id="invert" type="range" min="0" max="100" value="0">
+  </div>
   <button id="bc-reset" style="margin-top:5px;font-size:50%;padding:3px 6px;color:#666;">リセット</button><br>
 
 

--- a/popup.html
+++ b/popup.html
@@ -21,6 +21,18 @@
     <label for="contrast">コントラスト</label><br>
     <input id="contrast" type="range" min="-100" max="100" value="0">
   </div>
+  <div style="margin-top:5px;">
+    <label for="hue">色相</label><br>
+    <input id="hue" type="range" min="-180" max="180" value="0">
+  </div>
+  <div style="margin-top:5px;">
+    <label for="saturate">彩度</label><br>
+    <input id="saturate" type="range" min="-100" max="100" value="0">
+  </div>
+  <div style="margin-top:5px;">
+    <label for="invert">階調の反転</label><br>
+    <input id="invert" type="range" min="0" max="100" value="0">
+  </div>
   <button id="bc-reset" style="margin-top:5px;font-size:50%;padding:3px 6px;color:#666;">リセット</button><br>
 
   <select id="rotate" name="回転" style="display:none;">


### PR DESCRIPTION
## Summary
- extend filter settings with hue, saturation and invert values
- add sliders for the new filters in popup and options UIs
- update popup logic to handle new sliders and send update messages
- expand content script to apply the additional filters

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842aac038fc8329a478a6a8e82c7b68