### PR TITLE
Throttle rotate writes to storage

### DIFF
--- a/js/dial.js
+++ b/js/dial.js
@@ -95,9 +95,6 @@
   }
 
   function commitAngle() {
-    // ストレージへ保存
-    chrome.storage.sync.set({ Rotate: String(currentAngle) });
-
     // 互換 select に反映
     if (rotateSel) {
       if (![...rotateSel.options].some(o => o.value === String(currentAngle))) {
@@ -110,6 +107,15 @@
       if (typeof window.jQuery === 'function') {
         window.jQuery(rotateSel).change();
       }
+    }
+
+    // ストレージへ保存（スロットル）
+    if (typeof window.scheduleRotate === 'function') {
+      window.scheduleRotate(currentAngle);
+    } else {
+      chrome.storage.sync.set({ Rotate: String(currentAngle) }, () => {
+        chrome.runtime.sendMessage({type:'refresh'});
+      });
     }
 
     // 外部フック

--- a/js/popup.js
+++ b/js/popup.js
@@ -76,11 +76,35 @@ $(function(){
       chrome.storage.sync.set(option);
     };
 
+      var rotatePending = null;
+      var rotateTimer  = null;
+
+      var flushRotate = function(){
+        if (rotateTimer) {
+          clearTimeout(rotateTimer);
+          rotateTimer = null;
+        }
+        if (rotatePending !== null) {
+          var option = {Rotate: rotatePending};
+          rotatePending = null;
+          chrome.storage.sync.set(option, function(){
+            chrome.runtime.sendMessage({type:'refresh'});
+          });
+        }
+      };
+
+      var scheduleRotate = function(angle){
+        rotatePending = String(angle);
+        if (rotateTimer) clearTimeout(rotateTimer);
+        rotateTimer = setTimeout(flushRotate, 100);
+      };
+
+      // 外部からも呼び出せるように公開
+      window.scheduleRotate = scheduleRotate;
+
       var setRotate = function(){
         var Rotate = $("#rotate").children(':selected').val();
-        var option = {};
-        option.Rotate = Rotate;
-        chrome.storage.sync.set(option);
+        scheduleRotate(Rotate);
       };
 
       // -- filter sliders --


### PR DESCRIPTION
## Summary
- avoid hitting `chrome.storage` write limits by queueing rotation updates
- expose `scheduleRotate` so jog dial can invoke it
- update dial to use the new throttled function

## Testing
- `node -c js/popup.js`
- `node -c js/dial.js`


------
https://chatgpt.com/codex/tasks/task_e_6842d5c461008329b192dd950ef8ed3e