### PR TITLE
Add color adjustment toggle

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -204,6 +204,12 @@ $(function(){
       $("#invert").on('input change', function(){ setInvert(); });
       $("#bc-reset").click(function(){ resetBC(); });
       $("#applyOnLoad").change(function(){ setApplyOnLoad(); });
+      $("#color-toggle").click(function(){
+        $("#color-controls").slideToggle(100, function(){
+          var visible = $("#color-controls").is(":visible");
+          $("#color-toggle").text(visible ? "色調整 🔼" : "色調整 🔽");
+        });
+      });
 
     // ジョグダイアル → select を動かすための連携
     if (typeof window.jogDialAngleHook === 'function') {

--- a/popup.html
+++ b/popup.html
@@ -31,6 +31,8 @@
 
   <!-- Brightness and Contrast controls -->
   <font size="-1">
+  <div id="color-toggle" style="margin-top:5px; cursor:pointer; font-weight:bold;">色調整 🔽</div>
+  <div id="color-controls" style="display:none;">
   <div style="margin-top:5px;">
     <label for="brightness">明るさ</label><br>
     <input id="brightness" type="range" min="-100" max="100" value="0">
@@ -51,8 +53,9 @@
     <label for="invert">階調の反転</label><br>
     <input id="invert" type="range" min="0" max="100" value="0">
   </div>
-  </font>
   <button id="bc-reset" style="margin-top:5px;font-size:50%;padding:3px 6px;color:#666;">リセット</button><br>
+  </div>
+  </font>
   <div style="margin-top:5px;">
     <label><input type="checkbox" id="applyOnLoad"> 読み込み時に適用</label>
   </div>


### PR DESCRIPTION
## Summary
- add a new "色調整" toggle above brightness slider
- hide color sliders and reset button by default, toggling with slide animation

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68439f4bc71083298ac8844b74827cac